### PR TITLE
Pokemon image url

### DIFF
--- a/Data/PokemonSeeder.cs
+++ b/Data/PokemonSeeder.cs
@@ -15,7 +15,7 @@ public static class PokemonSeeder
     {
         if (await context.Pokemon.AnyAsync()) return;
 
-        var response = await httpClient.GetAsync("https://pokeapi.co/api/v2/pokemon?limit=1000");
+        var response = await httpClient.GetAsync("https://pokeapi.co/api/v2/pokemon?limit=649");
         if (response.IsSuccessStatusCode)
         {
             var json = await response.Content.ReadAsStringAsync();
@@ -23,20 +23,24 @@ public static class PokemonSeeder
             var root = jsonData.RootElement.GetProperty("results");
 
             var pokemons = new List<Pokemon>();
+            int pokemonNumber = 1;
 
             foreach (var element in root.EnumerateArray())
             {
                 var name = element.GetProperty("name").GetString() ?? "unknown";
                 var apiUrl = element.GetProperty("url").GetString() ?? string.Empty;
+                var imageUrl = $"https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/dream-world/{pokemonNumber}.svg";
 
                 var pokemon = new Pokemon
                 {
                     Name = name,
+                    ImageUrl = imageUrl,
                     ApiUrl = apiUrl,
                     CreatedAt = DateTime.UtcNow
                 };
 
                 pokemons.Add(pokemon);
+                pokemonNumber++;
             }
 
             await context.Pokemon.AddRangeAsync(pokemons);

--- a/Migrations/20241118131933_InitialCreate.Designer.cs
+++ b/Migrations/20241118131933_InitialCreate.Designer.cs
@@ -12,7 +12,7 @@ using PokeLikeAPI.Data;
 namespace PRO05_BACK_Gaj_Khalos_Max.Migrations
 {
     [DbContext(typeof(PokeLikeDbContext))]
-    [Migration("20241114131415_InitialCreate")]
+    [Migration("20241118131933_InitialCreate")]
     partial class InitialCreate
     {
         /// <inheritdoc />
@@ -80,6 +80,11 @@ namespace PRO05_BACK_Gaj_Khalos_Max.Migrations
                     b.Property<DateTime>("CreatedAt")
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("created_at");
+
+                    b.Property<string>("ImageUrl")
+                        .IsRequired()
+                        .HasColumnType("text")
+                        .HasColumnName("image_url");
 
                     b.Property<int>("Likes")
                         .HasColumnType("integer")

--- a/Migrations/20241118131933_InitialCreate.cs
+++ b/Migrations/20241118131933_InitialCreate.cs
@@ -36,6 +36,7 @@ namespace PRO05_BACK_Gaj_Khalos_Max.Migrations
                     id = table.Column<int>(type: "integer", nullable: false)
                         .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
                     name = table.Column<string>(type: "text", nullable: false),
+                    image_url = table.Column<string>(type: "text", nullable: false),
                     api_url = table.Column<string>(type: "text", nullable: false),
                     likes = table.Column<int>(type: "integer", nullable: false),
                     created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)

--- a/Migrations/PokeLikeDbContextModelSnapshot.cs
+++ b/Migrations/PokeLikeDbContextModelSnapshot.cs
@@ -78,6 +78,11 @@ namespace PRO05_BACK_Gaj_Khalos_Max.Migrations
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("created_at");
 
+                    b.Property<string>("ImageUrl")
+                        .IsRequired()
+                        .HasColumnType("text")
+                        .HasColumnName("image_url");
+
                     b.Property<int>("Likes")
                         .HasColumnType("integer")
                         .HasColumnName("likes");

--- a/Models/Pokemon.cs
+++ b/Models/Pokemon.cs
@@ -3,6 +3,7 @@ namespace PokeLikeAPI.Models
     public class Pokemon : BaseEntity
     {
         public required string Name { get; set; }
+        public required string ImageUrl { get; set; }
         public required string ApiUrl { get; set; }
         public int Likes { get; set; }
     }


### PR DESCRIPTION
### Summary
This pull request introduces enhancements to the `Pokemon` model and updates the database seed data, while also aligning the database schema with new migrations to reflect recent changes.

### Updates:
- Added an `imageUrl` field to the `Pokemon` model, allowing for the storage of image URLs.
- Limited the database seed to the first 649 Pokémon, aligning with the original generation limits and incorporating SVG image URLs from the PokeAPI sprites. (example: https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/dream-world/1.svg)
- Updated migrations to reflect the changes to the database schema, ensuring consistency and accurate representation of the model updates.

These changes enhance the data structure for Pokémon images, improve database seeding specificity, and maintain schema consistency for future development.

Closes #15