### PR TITLE
#17: PATCH Requests to update pokemon with number of likes when users like a pokemon

### DIFF
--- a/Models/Pokemon.cs
+++ b/Models/Pokemon.cs
@@ -7,4 +7,9 @@ namespace PokeLikeAPI.Models
         public required string ApiUrl { get; set; }
         public int Likes { get; set; }
     }
+
+    public class UpdatePokemonDto
+    {
+        public int? Likes { get; set; }
+    }
 }


### PR DESCRIPTION
### Summary

This pull request introduces a new feature for updating Pokémon likes and sets up supporting models to enhance data management and interaction.

### Updates:
- Added an `updatePokemonDto` model to handle data transfer objects (DTOs) for patching the `Pokemon` table, specifically designed to update the number of likes.
- Implemented a new route for patching the `Pokemon` table to modify the number of likes for a specified Pokémon entry, providing an interactive and responsive feature for user-driven data changes.

This update closes issue #17 and expands the application's capability to handle dynamic interactions with Pokémon data.