### PR TITLE
Don't accept merge!

### DIFF
--- a/Dtos/CreateCollectionDto.cs
+++ b/Dtos/CreateCollectionDto.cs
@@ -1,0 +1,11 @@
+namespace PokeLikeAPI.Dtos
+{
+    public class CreateCollectionDto
+    {
+        public string Name { get; set; } = "";
+        public int ThemeId { get; set; }
+        public int Likes { get; set; }
+        public string Password { get; set; } = "";
+        public List<int> PokemonIds { get; set; } = new List<int>();
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -140,8 +140,20 @@ app.MapPost("/collections", async (PokeLikeDbContext db, CreateCollectionDto dto
         Likes = dto.Likes,
         PasswordHash = passwordHash
     };
+    //add the collection to the database
     await db.Collections.AddAsync(collection);
     await db.SaveChangesAsync();
+
+// LOOK FURTHER INTO THIS IT'A ASSOCIATING WITH A NEW COLLECTION 
+    foreach (var pokemonId in dto.PokemonIds)
+    {
+        var pokemonCollection = new PokemonCollections
+        {
+            CollectionId = collection.Id,
+            PokemonId = pokemonId
+        };
+        await db.PokemonCollections.AddAsync(pokemonCollection);
+    }
 
 });
 

--- a/Program.cs
+++ b/Program.cs
@@ -127,6 +127,32 @@ app.MapPatch("/pokemon/{id}", async (PokeLikeDbContext db, int id, HttpRequest r
     return Results.Ok(pokemon);
 });
 
+app.MapPost("/collections", async (PokeLikeDbContext db, CreateCollectionDto dto) =>
+{
+    var passwordHash = BCrypt.Net.BCrypt.HashPassword(dto.Password);
+
+    var collection = new Collection
+    {
+        //collection object creates a new instance of the Collection entity, Populating it with data from the DTO.
+        //ThemeId is converted to a string assuming the model expects a string from the property.
+        Name = dto.Name,
+        ThemeId = dto.ThemeId.ToString(),
+        Likes = dto.Likes,
+        PasswordHash = passwordHash
+    };
+    await db.Collections.AddAsync(collection);
+    await db.SaveChangesAsync();
+
+});
+
+
+
+
+
+
+
+
+
 app.Run();
 
 


### PR DESCRIPTION
Title: Add Feature for Updating Pokémon Likes and Supporting Models
Description:
- This pull request introduces a new feature for updating Pokémon likes and sets up supporting models to enhance data management and interaction.

 Updates:

- Added UpdatePokemonDto Model:
- Introduced a data transfer object (DTO) specifically designed for patching the Pokémon table. This model facilitates the update of the number of likes for Pokémon entries.
- Implemented New Route for Patching Pokémon Table:
- Developed a new API route that allows for the modification of the number of likes for a specified Pokémon entry. This feature provides an interactive and responsive mechanism for user-driven data changes.

 Impact:
- Expands the application's capability to handle dynamic interactions with Pokémon data, enhancing user engagement and data management.
- Verify that the UpdatePokemonDto model correctly handles data validation and transformation.